### PR TITLE
Allow SimpleSAMLphp 1.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ test: composer
 
 composer:
 	docker-compose run --rm --user "0:0" cli composer install
+
+composerupdate:
+	docker-compose run --rm --user "0:0" cli composer update

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
   "minimum-stability": "stable",
   "require": {
     "php": ">=5.4",
-    "roave/security-advisories": "dev-master",
     "simplesamlphp/simplesamlphp": "~1.18.6"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.6.1",
+    "roave/security-advisories": "dev-master",
     "satooshi/php-coveralls": "^1.0.1"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "minimum-stability": "stable",
   "require": {
     "php": ">=5.4",
-    "simplesamlphp/simplesamlphp": "~1.18.6"
+    "simplesamlphp/simplesamlphp": "~1.18.6 || ~1.19.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.6.1",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "php": ">=5.4",
+    "php": ">=5.6",
     "simplesamlphp/simplesamlphp": "~1.18.6 || ~1.19.0"
   },
   "require-dev": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   cli:
-    image: silintl/php7-apache:latest
+    image: silintl/php7:7.4
     volumes:
       - ./:/data
     working_dir: /data


### PR DESCRIPTION
### Fixed
- Move Roave Security Advisories to a dev-dependency
- Allow SimpleSAMLphp 1.19
- Raise minimum PHP version to match that of SSP 1.18.6
- Switch to our current PHP 7.4 Docker image for tests