### PR TITLE
Handle null array error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "php": ">=5.6",
+    "php": ">=7.0",
     "simplesamlphp/simplesamlphp": "~1.18.6 || ~1.19.0"
   },
   "require-dev": {

--- a/src/DiscoUtils.php
+++ b/src/DiscoUtils.php
@@ -41,7 +41,7 @@ class DiscoUtils
     ) {
 
         $spEntries = Metadata::getSpMetadataEntries($metadataPath);
-        $spMetadata = $spEntries[$spEntityId];
+        $spMetadata = $spEntries[$spEntityId] ?? [];
 
         $reducedIdps = [];
 


### PR DESCRIPTION
### Fixed
- Avoid errors when no matching metadata is found by `getReducedIdpList()`

### Changed
- Raise the minimum supported version of PHP to 7.0