### PR TITLE
Remove composer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
   "description": "SimpleSAMLphp related utility classes",
   "type": "library",
   "license": "MIT",
-  "version": "2.0.0",
   "minimum-stability": "stable",
   "require": {
     "php": "^8.1",


### PR DESCRIPTION
Packagist complains that some tags are ignored. This should fix that.

> Some tags were ignored because of a version mismatch in composer.json, [read more](https://blog.packagist.com/tagged-a-new-release-for-composer-and-it-wont-show-up-on-packagist/).
[View Last Update Log](https://packagist.org/packages/sil-org/yii2-email-log-target#)